### PR TITLE
Fix: Images under assets/img not showing (wrong file extensions/references)

### DIFF
--- a/blog/blog-list.js
+++ b/blog/blog-list.js
@@ -63,7 +63,7 @@ function renderBlogs(blogsToRender) {
         <div class="card-footer">
           <div class="post-author">
             <a href="#">
-              <img src="../assets/img/mypic.webp" alt="" class="avatar rounded-circle">
+              <img src="../assets/img/mypic-removebg-preview.png" alt="" class="avatar rounded-circle">
               <span class="author">${blog.author}</span>
             </a>
           </div>

--- a/blog/index.html
+++ b/blog/index.html
@@ -7,8 +7,8 @@
   <title>Blog | DeepakV Portfolio</title>
   <meta content="Blog posts by Deepak Vishwakarma" name="description">
   <meta content="blog, devops, deepakv, articles" name="keywords">
-  <link href="../assets/img/favicon.png" rel="icon">
-  <link href="../assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+  <link href="../assets/img/mypic-removebg-preview.png" rel="icon">
+  <link href="../assets/img/mypic-removebg-preview.png" rel="apple-touch-icon">
   <link href="../assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
   <link href="../assets/vendor/bootstrap-icons/bootstrap-icons.css" rel="stylesheet">
   <link href="../assets/vendor/glightbox/css/glightbox.min.css" rel="stylesheet">
@@ -20,7 +20,7 @@
   <header id="header" class="fixed-top">
     <div class="container d-flex align-items-center justify-content-between">
       <h1 class="logo"><a href="../index.html">Welcome To DevOps World</a></h1>
-      <a href="../index.html" class="logo"><img src="../assets/img/logo.png" alt="" class="img-fluid"></a>
+      <!-- <a href="../index.html" class="logo"><img src="../assets/img/logo.png" alt="" class="img-fluid"></a> -->
       <nav id="navbar" class="navbar">
         <ul>
           <li><a class="nav-link scrollto" href="../index.html#hero">Home</a></li>

--- a/index.html
+++ b/index.html
@@ -18,13 +18,13 @@
   <meta property="og:url" content="https://deepakv30.github.io/">
   <meta property="og:title" content="Deepak Vishwakarma - DevSecOps Engineer">
   <meta property="og:description" content="DevSecOps Engineer specializing in GitLab Administration, DevOps Automation, and Cloud Infrastructure.">
-  <meta property="og:image" content="https://deepakv30.github.io/assets/img/mypic.webp">
+  <meta property="og:image" content="https://deepakv30.github.io/assets/img/mypic-removebg-preview.png">
   
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="Deepak Vishwakarma - DevSecOps Engineer">
   <meta name="twitter:description" content="DevSecOps Engineer specializing in GitLab Administration, DevOps Automation, and Cloud Infrastructure.">
-  <meta name="twitter:image" content="https://deepakv30.github.io/assets/img/mypic.webp">
+  <meta name="twitter:image" content="https://deepakv30.github.io/assets/img/mypic-removebg-preview.png">
   
   <!-- Additional SEO Meta Tags -->
   <meta name="author" content="Deepak Vishwakarma">
@@ -32,8 +32,8 @@
   <link rel="canonical" href="https://deepakv30.github.io/">
 
   <!-- Favicons -->
-  <link href="assets/img/favicon.png" rel="icon">
-  <link href="assets/img/apple-touch-icon.png" rel="apple-touch-icon">
+  <link href="assets/img/mypic-removebg-preview.png" rel="icon">
+  <link href="assets/img/mypic-removebg-preview.png" rel="apple-touch-icon">
 
   <!-- Vendor CSS Files -->
   <link href="assets/vendor/bootstrap/css/bootstrap.min.css" rel="stylesheet">
@@ -123,7 +123,7 @@
     "@type": "Person",
     "name": "Deepak Vishwakarma",
     "url": "https://deepakv30.github.io/",
-    "image": "https://deepakv30.github.io/assets/img/mypic.webp",
+    "image": "https://deepakv30.github.io/assets/img/mypic-removebg-preview.png",
     "sameAs": [
       "https://www.linkedin.com/in/deepakv30/",
       "https://github.com/deepakv30",
@@ -192,7 +192,7 @@
   </header><!-- End Header -->
 
   <!-- ======= Hero Section ======= -->
-  <div id="hero" class="hero route bg-image" data-src="assets/img/hero-bg.webp">
+  <div id="hero" class="hero route bg-image" data-src="assets/img/hero-bg.jpg">
     <div class="overlay-itro"></div>
     <div class="hero-content display-table">
       <div class="table-cell">
@@ -471,7 +471,7 @@
           <div class="col-md-4">
             <div class="card card-project">
               <div class="card-img">
-                <a href="js-calculator/index.html" target="_blank" rel="noopener"><img src="assets/img/calculator.webp" alt="JavaScript Calculator Project Screenshot" class="img-fluid" loading="lazy"></a>
+                <a href="js-calculator/index.html" target="_blank" rel="noopener"><img src="assets/img/hero-bg2.jpg" alt="JavaScript Calculator Project Screenshot" class="img-fluid" loading="lazy"></a>
               </div>
               <div class="card-body">
                 <div class="card-category-box">
@@ -487,7 +487,7 @@
               <div class="card-footer">
                 <div class="post-author">
                   <a href="#">
-                    <img src="assets/img/mypic.webp" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
+                    <img src="assets/img/mypic-removebg-preview.png" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
                     <span class="author">Deepak Vishwakarma</span>
                   </a>
                 </div>
@@ -500,7 +500,7 @@
           <div class="col-md-4">
             <div class="card card-project">
               <div class="card-img">
-                <a href="Todo-Application/index.html" target="_blank" rel="noopener"><img src="assets/img/Todo-Application.webp" alt="Todo Application Project Screenshot" class="img-fluid" loading="lazy"></a>
+                <a href="Todo-Application/index.html" target="_blank" rel="noopener"><img src="assets/img/Todo-Application.png" alt="Todo Application Project Screenshot" class="img-fluid" loading="lazy"></a>
               </div>
               <div class="card-body">
                 <div class="card-category-box">
@@ -516,7 +516,7 @@
               <div class="card-footer">
                 <div class="post-author">
                   <a href="#">
-                    <img src="assets/img/mypic.webp" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
+                    <img src="assets/img/mypic-removebg-preview.png" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
                     <span class="author">Deepak Vishwakarma</span>
                   </a>
                 </div>
@@ -529,7 +529,7 @@
           <div class="col-md-4">
             <div class="card card-project">
               <div class="card-img">
-                <a href="https://github.com/deepakv30/AlienInvasion" target="_blank" rel="noopener noreferrer"><img src="assets/img/alien-invasion.webp" alt="Alien Invasion Game Project Screenshot" class="img-fluid" loading="lazy"></a>
+                <a href="https://github.com/deepakv30/AlienInvasion" target="_blank" rel="noopener noreferrer"><img src="assets/img/overlay-bg.jpg" alt="Alien Invasion Game Project Screenshot" class="img-fluid" loading="lazy"></a>
               </div>
               <div class="card-body">
                 <div class="card-category-box">
@@ -545,7 +545,7 @@
               <div class="card-footer">
                 <div class="post-author">
                   <a href="#">
-                    <img src="assets/img/mypic.webp" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
+                    <img src="assets/img/mypic-removebg-preview.png" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
                     <span class="author">Deepak Vishwakarma</span>
                   </a>
                 </div>
@@ -598,7 +598,7 @@
               <div class="card-footer">
                 <div class="post-author">
                   <a href="#">
-                    <img src="assets/img/mypic.webp" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
+                    <img src="assets/img/mypic-removebg-preview.png" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
                     <span class="author">Deepak Vishwakarma</span>
                   </a>
                 </div>
@@ -627,7 +627,7 @@
               <div class="card-footer">
                 <div class="post-author">
                   <a href="#">
-                    <img src="assets/img/mypic.webp" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
+                    <img src="assets/img/mypic-removebg-preview.png" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
                     <span class="author">Deepak Vishwakarma</span>
                   </a>
                 </div>
@@ -657,7 +657,7 @@
               <div class="card-footer">
                 <div class="post-author">
                   <a href="#">
-                    <img src="assets/img/mypic.webp" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
+                    <img src="assets/img/mypic-removebg-preview.png" alt="Deepak Vishwakarma Profile Picture" class="avatar rounded-circle" loading="lazy">
                     <span class="author">Deepak Vishwakarma</span>
                   </a>
                 </div>
@@ -675,7 +675,7 @@
     </section><!-- End Blog Section -->
 
     <!-- ======= Contact Section ======= -->
-    <section id="contact" class="paralax-mf footer-paralax bg-image sect-mt4 route" style="background-image: url(assets/img/overlay-bg.webp)">
+    <section id="contact" class="paralax-mf footer-paralax bg-image sect-mt4 route" style="background-image: url(assets/img/overlay-bg.jpg)">
       <div class="overlay-mf"></div>
       <div class="container">
         <div class="row">


### PR DESCRIPTION
## Problem

Images referenced in the webpage (homepage and blog) were not displaying because:

- All references pointed to non-existent `.webp` files (e.g. `mypic.webp`, `hero-bg.webp`, `overlay-bg.webp`, `Todo-Application.webp`, `calculator.webp`, `alien-invasion.webp`)
- The actual image files committed under `assets/img/` are the original `.jpg` and `.png` versions:
  - `mypic-removebg-preview.png`
  - `hero-bg.jpg`, `hero-bg2.jpg`
  - `overlay-bg.jpg`
  - `Todo-Application.png`
  - coverpage*.jpg (unused)
- Missing favicons (`favicon.png`, `apple-touch-icon.png`) and `logo.png` (never added post "WebP conversion" documented in IMPROVEMENTS.md but files not present)

This was a result of references being updated for an image optimization pass to WebP, but the optimized `.webp` assets were not included in the repository.

## Fix

- Updated all local image `src`, `data-src`, `url()`, OpenGraph, Twitter, JSON-LD, and avatar references in `index.html` to point to the actual existing files with correct extensions.
- Mapped the two missing project thumbnail images (no source files) to other available images from `assets/img/` (hero-bg2.jpg and overlay-bg.jpg) so cards render without 404s.
- Updated favicons/apple-touch-icon to use the existing profile PNG (functional, if not ideal).
- Commented the non-existent `logo.png` reference in `blog/index.html` (to be consistent with the logo fix already applied in main `index.html`).
- Fixed the avatar reference in `blog/blog-list.js`.

## Files changed
- index.html
- blog/index.html
- blog/blog-list.js

## Testing
- Images (hero background, project thumbs, avatars in cards, contact overlay bg, favicons) should now load from assets/img correctly.
- No external dependencies changed.

This resolves the broken images issue on the deployed GitHub Pages site.